### PR TITLE
fix sed for uptime

### DIFF
--- a/zfetch.sh
+++ b/zfetch.sh
@@ -169,7 +169,7 @@ procuptime () {
 
 host=$(cat /proc/sys/kernel/hostname)
 kernel=$(sed "s/version // ; s/ (.*//" /proc/version)
-uptime=$(uptime -p 2>/dev/null || procuptime | sed "s/up //")
+uptime=$(echo $(uptime -p 2>/dev/null || procuptime) | sed "s/up //")
 shell=$(printf "$SHELL" | sed "s/\/bin\///" | sed "s/\/usr//")
 
 printf "${dscolor}${dslogo1}$USER@$host\n"


### PR DESCRIPTION
Correctly removes the "up " from the uptime line when not using the `procuptime` function.